### PR TITLE
Simplifying the example

### DIFF
--- a/sum.pyx
+++ b/sum.pyx
@@ -2,27 +2,30 @@ cimport numpy as np
 import numpy as np
 cimport cython
 from cython.parallel import prange
+from libc.stdlib cimport malloc
 
-def fun_sum():
-
-    cdef np.float64_t[:] result = np.zeros(1)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def sum():
+    cdef np.float64_t * result
+    result = <np.float64_t *> malloc(sizeof(np.float64_t))
     cdef int j
-    cdef np.float64_t a = 3.0
 
     with nogil:
-        for j in prange(0, 10000):
-            result[0] += a + j
+        for j in prange(0, 10000000):
+            result[0] += j
 
-    return np.array(result)
+    return result[0]
 
-def fun_sum_scalar():
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def sum_scalar():
 
     cdef np.float64_t result = 0
     cdef int j
-    cdef np.float64_t a = 3.0
 
     with nogil:
-        for j in prange(0, 10000):
-            result += a + j
+        for j in prange(0, 10000000):
+            result += j
 
     return result

--- a/test.py
+++ b/test.py
@@ -1,8 +1,6 @@
 import sum
 import numpy as np
 
-for i in range(100):
-    print(sum.fun_sum())
+print(sum.sum())
 
-for i in range(100):
-    print(sum.fun_sum_scalar())
+print(sum.sum_scalar())


### PR DESCRIPTION
So, I've removed memoryviews, dropped bounds checking and wraparound to **greatly** simply the C code. This result in code generation for the scalar and array case to be a lot more consistent.

After that, I was able to go through the C code with much greater success.

For the scalar case we get:
```
                #ifdef _OPENMP
                #pragma omp parallel reduction(+:__pyx_v_result)
                #endif /* _OPENMP */
                {
                    #ifdef _OPENMP
                    #pragma omp for firstprivate(__pyx_v_j) lastprivate(__pyx_v_j)
                    #endif /* _OPENMP */
                    for (__pyx_t_1 = 0; __pyx_t_1 < __pyx_t_2; __pyx_t_1++){
                        {
                            __pyx_v_j = (int)(0 + 1 * __pyx_t_1);

                            /* "sum.pyx":29
 *     with nogil:
 *         for j in prange(0, 10000000):
 *             result += j             # <<<<<<<<<<<<<<
 * 
 *     return result
 */
                            __pyx_v_result = (__pyx_v_result + __pyx_v_j);
                        }
                    }
                }
            }
        }
```

when I compare with the code for the array case:

```
                #ifdef _OPENMP
                #pragma omp parallel private(__pyx_t_3)
                #endif /* _OPENMP */
                {
                    #ifdef _OPENMP
                    #pragma omp for firstprivate(__pyx_v_j) lastprivate(__pyx_v_j)
                    #endif /* _OPENMP */
                    for (__pyx_t_1 = 0; __pyx_t_1 < __pyx_t_2; __pyx_t_1++){
                        {
                            __pyx_v_j = (int)(0 + 1 * __pyx_t_1);

                            /* "sum.pyx":16
 *     with nogil:
 *         for j in prange(0, 10000000):
 *             result[0] += j             # <<<<<<<<<<<<<<
 * 
 *     return result[0]
 */
                            __pyx_t_3 = 0;
                            (__pyx_v_result[__pyx_t_3]) = ((__pyx_v_result[__pyx_t_3]) + __pyx_v_j);
                        }
                    }
                }
            }
        }
```

you can see that these are almost identical for this simple case, but for some reason cython didn't realise the array case was a reduction!

Build this with `python3 setup.py install --user`,
run `test.py` and find the outputs differ:
```
3124998750000.0
49999995000000.0
```

Now open the generated C file and change the line,
`#pragma omp parallel private(__pyx_t_3)`
to
`#pragma omp parallel reduction(+:__pyx_v_result[:1]) private(__pyx_t_3) `
and then re-build by again doing `python3 setup.py install --user`

Now run the `test.py` and find:
```
49999995000000.0
49999995000000.0
```